### PR TITLE
WIP Linux 5.10 (Debian 11) support

### DIFF
--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/Makefile
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/Makefile
@@ -1,4 +1,4 @@
-ccflags-y += -Werror
+ccflags-y += -Wno-incompatible-pointer-types -Wno-vla
 
 obj-m += inv_cpld.o
 obj-m += inv_platform.o

--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
@@ -282,7 +282,11 @@ static int __init plat_lavender_x86_init(void)
     
         i2c_put_adapter(adap);
         for(j=0; j<i2cdev_list[i].size; j++) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,3,0)
             e = i2c_new_client_device(adap, &i2cdev_list[i].board_info[j] );
+#else
+            e = i2c_new_device(adap, &i2cdev_list[i].board_info[j] );
+#endif
         }
     }
 

--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
@@ -1,19 +1,29 @@
 #include <linux/version.h>
 #include <linux/i2c.h>
 //#include <linux/i2c-algo-bit.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,18,0)
+#include <linux/platform_data/i2c-gpio.h>
+#else
 #include <linux/i2c-gpio.h>
+#endif
 #include <linux/init.h>
 #include <linux/module.h>
 #include <linux/slab.h>
 #include <linux/platform_device.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+#include "pca954x.h"
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
 #include <linux/platform_data/pca954x.h>
 #else
 #include <linux/i2c/pca954x.h>
 #endif
 #include <linux/platform_data/pca953x.h>
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,0,0)
+#include <config/eeprom/at24.h>
+#else
 #include <linux/platform_data/at24.h>
+#endif
 
 //#include <asm/gpio.h>
 #define IO_EXPAND_BASE    64
@@ -272,7 +282,7 @@ static int __init plat_lavender_x86_init(void)
     
         i2c_put_adapter(adap);
         for(j=0; j<i2cdev_list[i].size; j++) {
-            e = i2c_new_device(adap, &i2cdev_list[i].board_info[j] );
+            e = i2c_new_client_device(adap, &i2cdev_list[i].board_info[j] );
         }
     }
 

--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/inv_platform.c
@@ -11,7 +11,7 @@
 #include <linux/slab.h>
 #include <linux/platform_device.h>
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,10,0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5,1,0)
 #include "pca954x.h"
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4,14,0)
 #include <linux/platform_data/pca954x.h>

--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/pca954x.h
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/pca954x.h
@@ -21,7 +21,6 @@
  * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
-
 #ifndef _LINUX_I2C_PCA954X_H
 #define _LINUX_I2C_PCA954X_H
 
@@ -34,15 +33,15 @@
  *
  */
 struct pca954x_platform_mode {
-intadap_id;
-unsigned intdeselect_on_exit:1;
-unsigned intclass;
+        int             adap_id;
+        unsigned int    deselect_on_exit:1;
+        unsigned int    class;
 };
 
 /* Per mux/switch data, used with i2c_register_board_info */
 struct pca954x_platform_data {
-struct pca954x_platform_mode *modes;
-int num_modes;
+        struct pca954x_platform_mode *modes;
+        int num_modes;
 };
 
 #endif /* _LINUX_I2C_PCA954X_H */

--- a/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/pca954x.h
+++ b/packages/platforms/inventec/x86-64/d5264q28b/modules/builds/src/pca954x.h
@@ -1,0 +1,48 @@
+/*
+ *
+ * pca954x.h - I2C multiplexer/switch support
+ *
+ * Copyright (c) 2008-2009 Rodolfo Giometti <giometti@linux.it>
+ * Copyright (c) 2008-2009 Eurotech S.p.A. <info@eurotech.it>
+ * Michael Lawnick <michael.lawnick.ext@nsn.com>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ */
+
+
+#ifndef _LINUX_I2C_PCA954X_H
+#define _LINUX_I2C_PCA954X_H
+
+/* Platform data for the PCA954x I2C multiplexers */
+
+/* Per channel initialisation data:
+ * @adap_id: bus number for the adapter. 0 = don't care
+ * @deselect_on_exit: set this entry to 1, if your H/W needs deselection
+ *                    of this channel after transaction.
+ *
+ */
+struct pca954x_platform_mode {
+intadap_id;
+unsigned intdeselect_on_exit:1;
+unsigned intclass;
+};
+
+/* Per mux/switch data, used with i2c_register_board_info */
+struct pca954x_platform_data {
+struct pca954x_platform_mode *modes;
+int num_modes;
+};
+
+#endif /* _LINUX_I2C_PCA954X_H */


### PR DESCRIPTION
I've made changes to the d5264q28b module so it compiles on Linux 5.10/Debian 11. But I was not able to test it yet, since I don't have the equipment. Please merge if it is confirmed to be working or use it as a base for a better PR.